### PR TITLE
Expose bad webhook URLs as domain errors

### DIFF
--- a/examples/src/main/scala/zio/webhooks/example/BasicExample.scala
+++ b/examples/src/main/scala/zio/webhooks/example/BasicExample.scala
@@ -54,7 +54,7 @@ object BasicExample extends App {
       _ <- httpEndpointServer.start(port, httpApp).fork
       _ <- WebhookServer.getErrors.use(UStream.fromQueue(_).map(_.toString).foreach(putStrLnErr(_))).fork
       _ <- TestWebhookRepo.createWebhook(webhook)
-      _ <- nEvents.schedule(Schedule.fixed(333.micros)) foreach (TestWebhookEventRepo.createEvent)
+      _ <- nEvents.schedule(Schedule.fixed(1.milli)).foreach(TestWebhookEventRepo.createEvent)
     } yield ()
 
   /**

--- a/examples/src/main/scala/zio/webhooks/example/ManualServerExample.scala
+++ b/examples/src/main/scala/zio/webhooks/example/ManualServerExample.scala
@@ -54,7 +54,7 @@ object ManualServerExample extends App {
       _      <- httpEndpointServer.start(port, httpApp).fork
       _      <- TestWebhookRepo.createWebhook(webhook)
       _      <- nEvents
-                  .schedule(Schedule.fixed(333.micros))
+                  .schedule(Schedule.fixed(1.milli))
                   .foreach(TestWebhookEventRepo.createEvent)
                   .ensuring((server.shutdown *> putStrLn("Shutdown successful")).orDie)
     } yield ()

--- a/examples/src/main/scala/zio/webhooks/example/ShutdownOnFirstError.scala
+++ b/examples/src/main/scala/zio/webhooks/example/ShutdownOnFirstError.scala
@@ -57,11 +57,11 @@ object ShutdownOnFirstError extends App {
       _          <- errorFiber.join.onExit(_ => WebhookServer.shutdown.orDie *> httpFiber.interrupt)
     } yield ()
   }.catchAll {
-    case BadWebhookUrlError(id, badUrl) => putStrLnErr(s"Bad url for webhook with id ${id.value}: $badUrl")
-    case InvalidStateError(_, message)  => putStrLnErr(s"Invalid state: $message")
-    case MissingWebhookError(id)        => putStrLnErr(s"Missing webhook: $id")
-    case MissingEventError(key)         => putStrLnErr(s"Missing event: $key")
-    case MissingEventsError(keys)       => putStrLnErr(s"Missing events: $keys")
+    case BadWebhookUrlError(url, message) => putStrLnErr(s"""Bad url "$url", reason: $message """)
+    case InvalidStateError(_, message)    => putStrLnErr(s"Invalid state: $message")
+    case MissingWebhookError(id)          => putStrLnErr(s"Missing webhook: $id")
+    case MissingEventError(key)           => putStrLnErr(s"Missing event: $key")
+    case MissingEventsError(keys)         => putStrLnErr(s"Missing events: $keys")
   }
 
   def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =

--- a/examples/src/main/scala/zio/webhooks/example/ShutdownOnFirstError.scala
+++ b/examples/src/main/scala/zio/webhooks/example/ShutdownOnFirstError.scala
@@ -6,7 +6,7 @@ import zio._
 import zio.console._
 import zio.duration._
 import zio.magic._
-import zio.stream.{UStream, ZStream}
+import zio.stream._
 import zio.webhooks.WebhookError._
 import zio.webhooks._
 import zio.webhooks.backends.sttp.WebhookSttpClient
@@ -17,7 +17,7 @@ import zio.webhooks.testkit._
  */
 object ShutdownOnFirstError extends App {
 
-  private val goodEvents: ZStream[Any, Nothing, WebhookEvent] = UStream
+  private val goodEvents = UStream
     .iterate(0L)(_ + 1)
     .map { i =>
       WebhookEvent(

--- a/examples/src/main/scala/zio/webhooks/example/ShutdownOnFirstError.scala
+++ b/examples/src/main/scala/zio/webhooks/example/ShutdownOnFirstError.scala
@@ -7,6 +7,7 @@ import zio.console._
 import zio.duration._
 import zio.magic._
 import zio.stream.UStream
+import zio.webhooks.WebhookError._
 import zio.webhooks._
 import zio.webhooks.backends.sttp.WebhookSttpClient
 import zio.webhooks.testkit._
@@ -56,10 +57,11 @@ object ShutdownOnFirstError extends App {
       _          <- errorFiber.join.onExit(_ => WebhookServer.shutdown.orDie *> httpFiber.interrupt)
     } yield ()
   }.catchAll {
-    case WebhookError.InvalidStateError(_, message) => putStrLnErr(s"Invalid state: $message")
-    case WebhookError.MissingWebhookError(id)       => putStrLnErr(s"Missing webhook: $id")
-    case WebhookError.MissingEventError(key)        => putStrLnErr(s"Missing event: $key")
-    case WebhookError.MissingEventsError(keys)      => putStrLnErr(s"Missing events: $keys")
+    case BadWebhookUrlError(id, badUrl) => putStrLnErr(s"Bad url for webhook with id ${id.value}: $badUrl")
+    case InvalidStateError(_, message)  => putStrLnErr(s"Invalid state: $message")
+    case MissingWebhookError(id)        => putStrLnErr(s"Missing webhook: $id")
+    case MissingEventError(key)         => putStrLnErr(s"Missing event: $key")
+    case MissingEventsError(keys)       => putStrLnErr(s"Missing events: $keys")
   }
 
   def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =

--- a/webhooks-test/src/test/scala/zio/webhooks/WebhookServerSpec.scala
+++ b/webhooks-test/src/test/scala/zio/webhooks/WebhookServerSpec.scala
@@ -12,6 +12,7 @@ import zio.test._
 import zio.test.environment._
 import zio.webhooks.WebhookError._
 import zio.webhooks.WebhookServerSpecUtil._
+import zio.webhooks.testkit.TestWebhookHttpClient.{ StubResponse, StubResponses }
 import zio.webhooks.testkit._
 
 import java.time.Instant
@@ -34,7 +35,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             val expectedRequest = WebhookHttpRequest(webhook.url, event.content, event.headers)
 
             webhooksTestScenario(
-              stubResponses = UStream(Some(WebhookHttpResponse(200))),
+              stubResponses = UStream(Right(WebhookHttpResponse(200))),
               webhooks = List(webhook),
               events = List(event),
               ScenarioInterest.Requests
@@ -51,7 +52,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             )
 
             webhooksTestScenario(
-              stubResponses = UStream(Some(WebhookHttpResponse(200))),
+              stubResponses = UStream(Right(WebhookHttpResponse(200))),
               webhooks = List(webhook),
               events = List(event),
               ScenarioInterest.Webhooks
@@ -70,7 +71,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             val expectedStatuses = List(WebhookEventStatus.Delivering, WebhookEventStatus.Delivered)
 
             webhooksTestScenario(
-              stubResponses = UStream(Some(WebhookHttpResponse(200))),
+              stubResponses = UStream(Right(WebhookHttpResponse(200))),
               webhooks = List(webhook),
               events = List(event),
               ScenarioInterest.Events
@@ -85,7 +86,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             val eventsToNWebhooks = webhooks.map(_.id).flatMap(webhook => createPlaintextEvents(1)(webhook))
 
             webhooksTestScenario(
-              stubResponses = UStream.repeat(Some(WebhookHttpResponse(200))),
+              stubResponses = UStream.repeat(Right(WebhookHttpResponse(200))),
               webhooks = webhooks,
               events = eventsToNWebhooks,
               ScenarioInterest.Requests
@@ -96,7 +97,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             val webhook = singleWebhook(0, WebhookStatus.Disabled, WebhookDeliveryMode.SingleAtMostOnce)
 
             webhooksTestScenario(
-              stubResponses = UStream.repeat(Some(WebhookHttpResponse(200))),
+              stubResponses = UStream.repeat(Right(WebhookHttpResponse(200))),
               webhooks = List(webhook),
               events = createPlaintextEvents(n)(webhook.id),
               ScenarioInterest.Requests
@@ -108,7 +109,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
               singleWebhook(0, WebhookStatus.Unavailable(Instant.EPOCH), WebhookDeliveryMode.SingleAtMostOnce)
 
             webhooksTestScenario(
-              stubResponses = UStream.repeat(Some(WebhookHttpResponse(200))),
+              stubResponses = UStream.repeat(Right(WebhookHttpResponse(200))),
               webhooks = List(webhook),
               events = createPlaintextEvents(n)(webhook.id),
               ScenarioInterest.Requests
@@ -119,7 +120,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             val webhook = singleWebhook(id = 0, WebhookStatus.Enabled, WebhookDeliveryMode.BatchedAtMostOnce)
 
             webhooksTestScenario(
-              stubResponses = UStream.repeat(Some(WebhookHttpResponse(200))),
+              stubResponses = UStream.repeat(Right(WebhookHttpResponse(200))),
               webhooks = List(webhook),
               events = createPlaintextEvents(n)(webhook.id),
               ScenarioInterest.Requests
@@ -130,7 +131,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             val webhook = singleWebhook(id = 0, WebhookStatus.Enabled, WebhookDeliveryMode.SingleAtMostOnce)
 
             webhooksTestScenario(
-              stubResponses = UStream.repeat(Some(WebhookHttpResponse(404))),
+              stubResponses = UStream.repeat(Right(WebhookHttpResponse(404))),
               webhooks = List(webhook),
               events = createPlaintextEvents(n)(webhook.id),
               ScenarioInterest.Events
@@ -148,7 +149,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             val expectedErrorCount = missingWebhookIds.size
 
             webhooksTestScenario(
-              stubResponses = UStream(Some(WebhookHttpResponse(200))),
+              stubResponses = UStream(Right(WebhookHttpResponse(200))),
               webhooks = List.empty,
               events = eventsMissingWebhooks,
               ScenarioInterest.Errors
@@ -157,7 +158,10 @@ object WebhookServerSpec extends DefaultRunnableSpec {
                 hasSameElements(idRange.map(id => MissingWebhookError(WebhookId(id))))
               )
             }
-          }
+          },
+          testM("bad webhook URL errors are published") {
+            assertCompletesM
+          } @@ ignore
         ),
         suite("webhooks with at-least-once delivery")(
           testM("immediately retries once on non-200 response") {
@@ -166,7 +170,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             val events = createPlaintextEvents(1)(webhook.id)
 
             webhooksTestScenario(
-              stubResponses = UStream(Some(WebhookHttpResponse(500)), Some(WebhookHttpResponse(200))),
+              stubResponses = UStream(Right(WebhookHttpResponse(500)), Right(WebhookHttpResponse(200))),
               webhooks = List(webhook),
               events = events,
               ScenarioInterest.Requests
@@ -178,7 +182,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             val events = createPlaintextEvents(1)(webhook.id)
 
             webhooksTestScenario(
-              stubResponses = UStream(None, Some(WebhookHttpResponse(200))),
+              stubResponses = UStream(Left(None), Right(WebhookHttpResponse(200))),
               webhooks = List(webhook),
               events = events,
               ScenarioInterest.Requests
@@ -190,7 +194,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             val events = createPlaintextEvents(1)(webhook.id)
 
             webhooksTestScenario(
-              stubResponses = UStream(None, None, Some(WebhookHttpResponse(200))),
+              stubResponses = UStream(Left(None), Left(None), Right(WebhookHttpResponse(200))),
               webhooks = List(webhook),
               events = events,
               ScenarioInterest.Requests
@@ -208,7 +212,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             val events  = createPlaintextEvents(1)(webhook.id)
 
             webhooksTestScenario(
-              stubResponses = UStream.repeat(None),
+              stubResponses = UStream.repeat(Left(None)),
               webhooks = List(webhook),
               events = events,
               ScenarioInterest.Webhooks
@@ -226,7 +230,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             val events  = createPlaintextEvents(n)(webhook.id)
 
             webhooksTestScenario(
-              stubResponses = UStream.repeat(None),
+              stubResponses = UStream.repeat(Left(None)),
               webhooks = List(webhook),
               events = events,
               ScenarioInterest.Events
@@ -244,7 +248,8 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             val events  = createPlaintextEvents(1)(webhook.id)
 
             webhooksTestScenario(
-              stubResponses = UStream.fromIterable(List.fill(5)(None)) ++ UStream(Some(WebhookHttpResponse(200))),
+              stubResponses =
+                UStream.fromIterable(List.fill(5)(Left(None))) ++ UStream(Right(WebhookHttpResponse(200))),
               webhooks = List(webhook),
               events = events,
               ScenarioInterest.Requests
@@ -270,7 +275,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             val events = createPlaintextEvents(3)(webhook.id)
 
             webhooksTestScenario(
-              stubResponses = UStream(None) ++ UStream.repeat(Some(WebhookHttpResponse(200))),
+              stubResponses = UStream(Left(None)) ++ UStream.repeat(Right(WebhookHttpResponse(200))),
               webhooks = List(webhook),
               events = events,
               ScenarioInterest.Requests
@@ -291,8 +296,8 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             val expectedCount = n * 2
 
             for {
-              queues     <- ZIO.collectAll(Chunk.fill(100)(Queue.bounded[Option[WebhookHttpResponse]](2)))
-              _          <- ZIO.collectAll(queues.map(_.offerAll(List(None, Some(WebhookHttpResponse(200))))))
+              queues     <- ZIO.collectAll(Chunk.fill(100)(Queue.bounded[StubResponse](2)))
+              _          <- ZIO.collectAll(queues.map(_.offerAll(List(Left(None), Right(WebhookHttpResponse(200))))))
               testResult <- webhooksTestScenario(
                               stubResponses = request => queues.lift(request.content.toInt),
                               webhooks = webhooks,
@@ -324,7 +329,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             val actualRequests = ZIO.foreach(batches) { batch =>
               for {
                 _       <- ZIO.foreach_(batch)(TestWebhookEventRepo.createEvent)
-                _       <- responseQueue.offer(Some(WebhookHttpResponse(200)))
+                _       <- responseQueue.offer(Right(WebhookHttpResponse(200)))
                 request <- requests.take
               } yield request
             }
@@ -352,7 +357,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             ScenarioInterest.Requests
           ) { (requests, responseQueue) =>
             for {
-              _        <- responseQueue.offerAll(List.fill(10)(Some(WebhookHttpResponse(200))))
+              _        <- responseQueue.offerAll(List.fill(10)(Right(WebhookHttpResponse(200))))
               requests <- requests.takeBetween(minRequestsMade, minRequestsMade + 1)
             } yield assertTrue((minRequestsMade <= requests.size) && (requests.size <= maxRequestsMade))
           }
@@ -372,7 +377,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             for {
               _               <- ZIO.foreach_(testEvents) {
                                    ZIO.foreach_(_)(TestWebhookEventRepo.createEvent) *>
-                                     responseQueue.offer(Some(WebhookHttpResponse(200)))
+                                     responseQueue.offer(Right(WebhookHttpResponse(200)))
                                  }
               deliveredEvents <- events
                                    .filterOutput(_.status == WebhookEventStatus.Delivered)
@@ -387,7 +392,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
           val plaintextEvents = createPlaintextEvents(4)(webhook.id)
 
           webhooksTestScenario(
-            stubResponses = UStream.repeat(Some(WebhookHttpResponse(200))),
+            stubResponses = UStream.repeat(Right(WebhookHttpResponse(200))),
             webhooks = List(webhook),
             events = jsonEvents ++ plaintextEvents,
             ScenarioInterest.Requests
@@ -398,7 +403,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
           val jsonEvents = createJsonEvents(100)(webhook.id)
 
           webhooksTestScenario(
-            stubResponses = UStream.repeat(Some(WebhookHttpResponse(200))),
+            stubResponses = UStream.repeat(Right(WebhookHttpResponse(200))),
             webhooks = List(webhook),
             events = jsonEvents,
             ScenarioInterest.Requests
@@ -418,7 +423,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
           val plaintextEvents = createPlaintextEvents(n)(webhook.id)
 
           webhooksTestScenario(
-            stubResponses = UStream.repeat(Some(WebhookHttpResponse(200))),
+            stubResponses = UStream.repeat(Right(WebhookHttpResponse(200))),
             webhooks = List(webhook),
             events = plaintextEvents,
             ScenarioInterest.Requests
@@ -446,10 +451,10 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             TestWebhookEventRepo.subscribeToEvents.map(_.filterOutput(_.status == WebhookEventStatus.Delivering)).use {
               events =>
                 for {
-                  responses <- Queue.unbounded[Option[WebhookHttpResponse]]
+                  responses <- Queue.unbounded[StubResponse]
                   server    <- WebhookServer.create
                   _         <- TestWebhookHttpClient.setResponse(_ => Some(responses))
-                  _         <- responses.offerAll(List(Some(WebhookHttpResponse(200)), Some(WebhookHttpResponse(200))))
+                  _         <- responses.offerAll(List(Right(WebhookHttpResponse(200)), Right(WebhookHttpResponse(200))))
                   _         <- server.start
                   _         <- server.shutdown
                   _         <- TestWebhookRepo.createWebhook(webhook)
@@ -465,10 +470,10 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             TestWebhookEventRepo.subscribeToEvents.map(_.filterOutput(_.status == WebhookEventStatus.Delivering)).use {
               events =>
                 for {
-                  responses <- Queue.unbounded[Option[WebhookHttpResponse]]
+                  responses <- Queue.unbounded[StubResponse]
                   server    <- WebhookServer.create
                   _         <- TestWebhookHttpClient.setResponse(_ => Some(responses))
-                  _         <- responses.offerAll(List(Some(WebhookHttpResponse(200)), Some(WebhookHttpResponse(200))))
+                  _         <- responses.offerAll(List(Right(WebhookHttpResponse(200)), Right(WebhookHttpResponse(200))))
                   _         <- server.start
                   _         <- TestWebhookRepo.createWebhook(webhook)
                   _         <- TestWebhookEventRepo.createEvent(testEvents(0))
@@ -491,10 +496,10 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             TestWebhookHttpClient.getRequests.use {
               requests =>
                 for {
-                  responses <- Queue.unbounded[Option[WebhookHttpResponse]]
+                  responses <- Queue.unbounded[StubResponse]
                   server    <- WebhookServer.create
                   _         <- TestWebhookHttpClient.setResponse(_ => Some(responses))
-                  _         <- responses.offerAll(List(None, None))
+                  _         <- responses.offerAll(List(Left(None), Left(None)))
                   _         <- server.start
                   _         <- TestWebhookRepo.createWebhook(webhook)
                   _         <- TestWebhookEventRepo.createEvent(event)
@@ -524,10 +529,10 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             TestWebhookHttpClient.getRequests.use {
               requests =>
                 for {
-                  responses <- Queue.unbounded[Option[WebhookHttpResponse]]
+                  responses <- Queue.unbounded[StubResponse]
                   server    <- WebhookServer.create
                   _         <- TestWebhookHttpClient.setResponse(_ => Some(responses))
-                  _         <- responses.offerAll(List(None, None, Some(WebhookHttpResponse(200))))
+                  _         <- responses.offerAll(List(Left(None), Left(None), Right(WebhookHttpResponse(200))))
                   _         <- server.start
                   _         <- TestWebhookRepo.createWebhook(webhook)
                   _         <- TestWebhookEventRepo.createEvent(event)
@@ -552,10 +557,10 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             (TestWebhookHttpClient.getRequests zip TestWebhookRepo.getWebhooks).use {
               case (requests, webhooks) =>
                 for {
-                  responses  <- Queue.unbounded[Option[WebhookHttpResponse]]
+                  responses  <- Queue.unbounded[StubResponse]
                   server     <- WebhookServer.create
                   _          <- TestWebhookHttpClient.setResponse(_ => Some(responses))
-                  _          <- responses.offerAll(List(None, None, Some(WebhookHttpResponse(200))))
+                  _          <- responses.offerAll(List(Left(None), Left(None), Right(WebhookHttpResponse(200))))
                   _          <- server.start
                   _          <- TestWebhookRepo.createWebhook(webhook)
                   _          <- TestWebhookEventRepo.createEvent(event)
@@ -681,7 +686,7 @@ object WebhookServerSpecUtil {
 
   // TODO: keep an eye on the duplication here
   def webhooksTestScenario[A](
-    stubResponses: WebhookHttpRequest => Option[Queue[Option[WebhookHttpResponse]]],
+    stubResponses: WebhookHttpRequest => StubResponses,
     webhooks: Iterable[Webhook],
     events: Iterable[WebhookEvent],
     scenarioInterest: ScenarioInterest[A]
@@ -698,16 +703,16 @@ object WebhookServerSpecUtil {
     }
 
   def webhooksTestScenario[A](
-    stubResponses: UStream[Option[WebhookHttpResponse]],
+    stubResponses: UStream[StubResponse],
     webhooks: Iterable[Webhook],
     events: Iterable[WebhookEvent],
     scenarioInterest: ScenarioInterest[A]
   )(
-    assertion: (Dequeue[A], Queue[Option[WebhookHttpResponse]]) => URIO[SpecEnv with TestClock, TestResult]
+    assertion: (Dequeue[A], Queue[StubResponse]) => URIO[SpecEnv with TestClock, TestResult]
   ): URIO[SpecEnv with TestClock with Has[WebhookServer] with Clock, TestResult] =
     ScenarioInterest.dequeueFor(scenarioInterest).use { dequeue =>
       for {
-        responseQueue <- Queue.bounded[Option[WebhookHttpResponse]](1)
+        responseQueue <- Queue.bounded[StubResponse](1)
         testFiber     <- assertion(dequeue, responseQueue).fork
         _             <- TestWebhookHttpClient.setResponse(_ => Some(responseQueue))
         _             <- ZIO.foreach_(webhooks)(TestWebhookRepo.createWebhook)

--- a/webhooks-test/src/test/scala/zio/webhooks/WebhookServerSpec.scala
+++ b/webhooks-test/src/test/scala/zio/webhooks/WebhookServerSpec.scala
@@ -185,7 +185,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
             ) { (errors, _) =>
               assertM(errors.take)(equalTo(expectedError))
             }
-          } @@ timeout(2.seconds) @@ failing
+          }
         ),
         suite("webhooks with at-least-once delivery")(
           testM("immediately retries once on non-200 response") {

--- a/webhooks-test/src/test/scala/zio/webhooks/WebhookServerSpec.scala
+++ b/webhooks-test/src/test/scala/zio/webhooks/WebhookServerSpec.scala
@@ -539,7 +539,7 @@ object WebhookServerSpec extends DefaultRunnableSpec {
                   _         <- server.shutdown
                 } yield assertCompletes
             }
-          } @@ nonFlaky,
+          },
           testM("resumes timeout duration for retries") {
             val webhook = singleWebhook(id = 0, WebhookStatus.Enabled, WebhookDeliveryMode.SingleAtLeastOnce)
             val event   = WebhookEvent(

--- a/webhooks/src/main/scala/zio/webhooks/WebhookError.scala
+++ b/webhooks/src/main/scala/zio/webhooks/WebhookError.scala
@@ -9,23 +9,29 @@ sealed trait WebhookError extends Product with Serializable
 object WebhookError {
 
   /**
+   * A [[BadWebhookUrlError]] occurs when a [[WebhookHttpClient]] detects a string that cannot be
+   * parsed into a URL for a [[Webhook]], as identified by its [[WebhookId]].
+   */
+  final case class BadWebhookUrlError(id: WebhookId, badUrl: String) extends WebhookError
+
+  /**
    * An [[InvalidStateError]] occurs when decoding `rawState` during event recovery fails with a
    * `message`.
    */
   final case class InvalidStateError(rawState: String, message: String) extends WebhookError
 
   /**
-   * A [[MissingWebhookError]] occurs when a webhook we expect to exist is missing.
+   * A [[MissingWebhookError]] occurs when a webhook expected to exist is missing.
    */
   final case class MissingWebhookError(id: WebhookId) extends WebhookError
 
   /**
-   * A [[MissingEventError]] occurs when a webhook event we expect to exist is missing.
+   * A [[MissingEventError]] occurs when a single webhook event expected to exist is missing.
    */
   final case class MissingEventError(key: WebhookEventKey) extends WebhookError
 
   /**
-   * A [[MissingEventsError]] occurs when multiple events we expect to exist are missing.
+   * A [[MissingEventsError]] occurs when multiple events expected to exist are missing.
    */
   final case class MissingEventsError(keys: NonEmptyChunk[WebhookEventKey]) extends WebhookError
 }

--- a/webhooks/src/main/scala/zio/webhooks/WebhookError.scala
+++ b/webhooks/src/main/scala/zio/webhooks/WebhookError.scala
@@ -12,7 +12,7 @@ object WebhookError {
    * A [[BadWebhookUrlError]] occurs when a [[WebhookHttpClient]] detects a string that cannot be
    * parsed into a URL for a [[Webhook]], as identified by its [[WebhookId]].
    */
-  final case class BadWebhookUrlError(id: WebhookId, badUrl: String) extends WebhookError
+  final case class BadWebhookUrlError(badUrl: String, message: String) extends WebhookError
 
   /**
    * An [[InvalidStateError]] occurs when decoding `rawState` during event recovery fails with a

--- a/webhooks/src/main/scala/zio/webhooks/WebhookHttpClient.scala
+++ b/webhooks/src/main/scala/zio/webhooks/WebhookHttpClient.scala
@@ -1,6 +1,9 @@
 package zio.webhooks
 
 import zio.IO
+import zio.webhooks.WebhookError.BadWebhookUrlError
+import zio.webhooks.WebhookHttpClient.HttpPostError
+
 import java.io.IOException
 
 /**
@@ -11,5 +14,9 @@ trait WebhookHttpClient {
   /**
    * [[WebhookHttpRequest]]s are sent over an HTTP POST method call.
    */
-  def post(request: WebhookHttpRequest): IO[IOException, WebhookHttpResponse]
+  def post(request: WebhookHttpRequest): IO[HttpPostError, WebhookHttpResponse]
+}
+
+object WebhookHttpClient {
+  type HttpPostError = Either[BadWebhookUrlError, IOException]
 }

--- a/webhooks/src/main/scala/zio/webhooks/backends/sttp/WebhookSttpClient.scala
+++ b/webhooks/src/main/scala/zio/webhooks/backends/sttp/WebhookSttpClient.scala
@@ -2,10 +2,11 @@ package zio.webhooks.backends.sttp
 
 import _root_.sttp.client._
 import _root_.sttp.client.asynchttpclient.zio.AsyncHttpClientZioBackend
+import sttp.model.Uri
 import zio._
-import zio.webhooks.WebhookHttpClient
-import zio.webhooks.WebhookHttpRequest
-import zio.webhooks.WebhookHttpResponse
+import zio.webhooks.WebhookError.BadWebhookUrlError
+import zio.webhooks.WebhookHttpClient.HttpPostError
+import zio.webhooks.{ WebhookHttpClient, WebhookHttpRequest, WebhookHttpResponse }
 
 import java.io.IOException
 
@@ -15,17 +16,18 @@ import java.io.IOException
  */
 final case class WebhookSttpClient(sttpClient: SttpClient) extends WebhookHttpClient {
 
-  def post(webhookRequest: WebhookHttpRequest): IO[IOException, WebhookHttpResponse] =
-    ZIO.effectSuspendTotal {
-      val sttpRequest = basicRequest
-        .post(uri"${webhookRequest.url}") // treat bad URLs as defects
-        .body(webhookRequest.content)
-        .headers(webhookRequest.headers.toMap)
-      sttpClient
-        .send(sttpRequest)
-        .map(response => WebhookHttpResponse(response.code.code))
-        .refineToOrDie[IOException]
-    }
+  def post(webhookRequest: WebhookHttpRequest): IO[HttpPostError, WebhookHttpResponse] =
+    for {
+      url        <- ZIO
+                      .fromEither(Uri.parse(webhookRequest.url))
+                      .mapError(msg => Left(BadWebhookUrlError(webhookRequest.url, msg)))
+      sttpRequest = basicRequest.post(url).body(webhookRequest.content).headers(webhookRequest.headers.toMap)
+      response   <- sttpClient
+                      .send(sttpRequest)
+                      .map(response => WebhookHttpResponse(response.code.code))
+                      .refineToOrDie[IOException]
+                      .mapError(Right(_))
+    } yield response
 }
 
 object WebhookSttpClient {

--- a/webhooks/src/main/scala/zio/webhooks/backends/sttp/WebhookSttpClient.scala
+++ b/webhooks/src/main/scala/zio/webhooks/backends/sttp/WebhookSttpClient.scala
@@ -6,7 +6,7 @@ import sttp.model.Uri
 import zio._
 import zio.webhooks.WebhookError.BadWebhookUrlError
 import zio.webhooks.WebhookHttpClient.HttpPostError
-import zio.webhooks.{ WebhookHttpClient, WebhookHttpRequest, WebhookHttpResponse }
+import zio.webhooks._
 
 import java.io.IOException
 


### PR DESCRIPTION
Bad URLs are now treated as checked domain errors that are exposed via the server's error hub, instead of as defects. `WebhookSttpClient` detects bad URLs by calling sttp's `URI.parse`.

closes #50
builds on top of work in #54, will be rebased once #54 is closed.