### PR TITLE
Use the companion objects for Clock and Console

### DIFF
--- a/webhooks/src/main/scala/zio/webhooks/internal/RetryController.scala
+++ b/webhooks/src/main/scala/zio/webhooks/internal/RetryController.scala
@@ -12,7 +12,6 @@ import java.time.Instant
  * dispatchers and state for each webhook.
  */
 private[webhooks] final case class RetryController(
-  private val clock: zio.Clock,
   private val config: WebhookServerConfig,
   private val errorHub: Hub[WebhookError],
   private val eventRepo: WebhookEventRepo,
@@ -54,11 +53,10 @@ private[webhooks] final case class RetryController(
     loadedState: PersistentRetries.PersistentRetryState
   ): IO[WebhookError, (RetryDispatcher, RetryState)] =
     for {
-      now   <- clock.instant
+      now   <- Clock.instant
       retry <- Queue.bounded[WebhookEvent](config.retry.capacity).map { retryQueue =>
                  (
                    RetryDispatcher(
-                     clock,
                      config,
                      errorHub,
                      eventRepo,
@@ -111,9 +109,8 @@ private[webhooks] final case class RetryController(
                             case None             =>
                               for {
                                 retryQueue     <- Queue.bounded[WebhookEvent](config.retry.capacity)
-                                now            <- clock.instant
+                                now            <- Clock.instant
                                 retryDispatcher = RetryDispatcher(
-                                                    clock,
                                                     config,
                                                     errorHub,
                                                     eventRepo,


### PR DESCRIPTION
Looks like there was some carry over from the transition. With `Clock` and `Console` being used as parameters instead of directly using their companion objects. I also tried to convert the `Console.printLine` usage to `ZIO.log` but it makes one of the tests time out so 🤷 .