### PR TITLE
Publish zio-webhooks-testkit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,6 @@ lazy val zioWebhooksTest = module("zio-webhooks-test", "webhooks-test")
 
 lazy val webhooksTestkit = module("zio-webhooks-testkit", "webhooks-testkit")
   .settings(
-    publish / skip := true,
     libraryDependencies ++= Seq(
       "dev.zio" %% "zio-test"     % zioVersion % "test",
       "dev.zio" %% "zio-test-sbt" % zioVersion % "test"


### PR DESCRIPTION
Testkit has some useful utilities for developers it would be nice to publish it as well (not sure if the `buildSettings` and `BuildInfoPlugin`s are also needed for this to work).