### PR TITLE
Remove Usages Of ZIO.succeedNow

### DIFF
--- a/webhooks/src/main/scala/zio/webhooks/internal/DequeueUtils.scala
+++ b/webhooks/src/main/scala/zio/webhooks/internal/DequeueUtils.scala
@@ -19,7 +19,7 @@ private[webhooks] object DequeueUtils {
 
       override def take(implicit trace: Trace): UIO[A] =
         d.take.flatMap { b =>
-          if (f(b)) ZIO.succeedNow(b)
+          if (f(b)) ZIO.succeed(b)
           else take
         }
 


### PR DESCRIPTION
This is an internal API and will be deleted.